### PR TITLE
MACE calculator

### DIFF
--- a/envs/environment-aurora.yml
+++ b/envs/environment-aurora.yml
@@ -46,6 +46,7 @@ dependencies:
   - pip:
     - git+https://gitlab.com/ase/ase.git
     - git+https://github.com/exalearn/colmena.git  # Fixes for streaming not yet on PyPI
+    - mace-torch
 
     # Install ccl manually for now, uncomment when SSL doesn't disagree between
     #  the following wheel's version and Sunspot/Aurora

--- a/envs/environment-cpu.yml
+++ b/envs/environment-cpu.yml
@@ -37,4 +37,5 @@ dependencies:
     - git+https://gitlab.com/ase/ase.git
     - --extra-index-url https://download.pytorch.org/whl/cpu
     - torch==2.3.*
+    - mace-torch
     - -e ..[test]

--- a/envs/environment-cuda11.yml
+++ b/envs/environment-cuda11.yml
@@ -44,5 +44,6 @@ dependencies:
     - git+https://gitlab.com/ase/ase.git
     - git+https://github.com/exalearn/colmena.git  # Fixes for streaming not yet on PyPI
     - rdkit==2023.03.2
+    - mace-torch
     - -e ..[test]
 

--- a/mofa/simulation/mace.py
+++ b/mofa/simulation/mace.py
@@ -1,0 +1,140 @@
+"""Run computations backed by MACE"""
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+import ase
+from mace.calculators import MACECalculator
+from ase import units
+from ase.filters import UnitCellFilter
+from ase.io import Trajectory
+from ase.optimize import LBFGS
+
+from mofa.model import MOFRecord
+from mofa.utils.conversions import read_from_string
+
+_mace_options = {
+    "default": {
+        "model": "medium",  # Can be 'small', 'medium', or 'large'
+        "device": "cpu",  # Can be 'cpu' or 'cuda'
+        "default_dtype": "float32",
+    }
+}
+
+
+def _load_structure(mof: MOFRecord, structure_source: tuple[str, int] | None):
+    """Read the appropriate input structure"""
+    if structure_source is None:
+        return mof.atoms
+    else:
+        traj, ind = structure_source
+        return read_from_string(mof.md_trajectory[traj][ind], "vasp")
+
+
+@dataclass
+class MACERunner:
+    """Interface for running pre-defined MACE workflows"""
+
+    run_dir: Path = Path("mace-runs")
+    """Path in which to store MACE computation files"""
+
+    def run_single_point(
+        self,
+        mof: MOFRecord,
+        level: str = "default",
+        structure_source: tuple[str, int] | None = None,
+    ) -> tuple[ase.Atoms, Path]:
+        """Perform a single-point computation at a certain level
+
+        Args:
+            mof: Structure to be run
+            level: Name of the level of computation to perform
+            structure_source: Name of the MD trajectory and frame ID from which to source the
+                input structure. Default is to use the as-assembled structure
+        Returns:
+            - Structure with computed properties
+            - Path to the run directory
+        """
+        atoms = _load_structure(mof, structure_source)
+        return self._run_mace(mof.name, atoms, "single", level)
+
+    def run_optimization(
+        self,
+        mof: MOFRecord,
+        level: str = "default",
+        structure_source: tuple[str, int] | None = None,
+        steps: int = 8,
+        fmax: float = 1e-2,
+    ) -> tuple[ase.Atoms, Path]:
+        """Perform a geometry optimization computation
+
+        Args:
+            mof: Structure to be run
+            level: Name of the level of computation to perform
+            structure_source: Name of the MD trajectory and frame ID from which to source the
+                input structure. Default is to use the as-assembled structure
+            steps: Maximum number of optimization steps
+            fmax: Convergence threshold for optimization
+        Returns:
+            - Relaxed structure
+            - Path to the run directory
+        """
+        atoms = _load_structure(mof, structure_source)
+        return self._run_mace(mof.name, atoms, "optimize", level, steps, fmax)
+
+    def _run_mace(
+        self,
+        name: str,
+        atoms: ase.Atoms,
+        action: str,
+        level: str,
+        steps: int = 8,
+        fmax: float = 1e-2,
+    ) -> tuple[ase.Atoms, Path]:
+        """Run MACE in a special directory
+
+        Args:
+            name: Name used for the start of the directory
+            atoms: Starting structure to use
+            action: Which action to perform (single, optimize)
+            level: Level of accuracy to use
+            steps: Number of steps to run
+            fmax: Convergence threshold for optimization
+        Returns:
+            - Structure with computed properties
+            - Absolute path to the run directory
+        """
+        if level not in _mace_options:
+            raise ValueError(f"No presets for {level}")
+        options = _mace_options[level]
+
+        # Create and move to output directory
+        out_dir = self.run_dir / f"{name}-{action}-{level}"
+        start_dir = Path().cwd()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        os.chdir(out_dir)
+
+        try:
+            # Initialize MACE calculator
+            calc = MACECalculator(**options)
+            atoms = atoms.copy()
+            atoms.calc = calc
+
+            # Run the calculation
+            if action == "single":
+                atoms.get_potential_energy()
+            elif action == "optimize":
+                ecf = UnitCellFilter(atoms, hydrostatic_strain=False)
+                with Trajectory("relax.traj", mode="w") as traj:
+                    dyn = LBFGS(ecf, logfile="relax.log", trajectory=traj)
+                    dyn.run(fmax=fmax, steps=steps)
+            else:
+                raise ValueError(f"Action not supported: {action}")
+
+            # Write the result to disk for easy retrieval
+            atoms.write("atoms.json")
+        finally:
+            os.chdir(start_dir)
+
+        return atoms, out_dir.absolute()

--- a/mofa/simulation/mace.py
+++ b/mofa/simulation/mace.py
@@ -14,16 +14,12 @@ from ase.optimize import LBFGS
 from mofa.model import MOFRecord
 from mofa.utils.conversions import read_from_string
 
-# Default model paths from MACE's pretrained models
-_default_model_path = (
-    "mace-mp-0"  # This will use MACE's built-in Materials Project model
-)
-
 _mace_options = {
     "default": {
-        "model_paths": _default_model_path,  # Using Materials Project pretrained model
+        "model": "medium",  # Can be 'small', 'medium', or 'large'
         "device": "cpu",  # Can be 'cpu' or 'cuda'
         "default_dtype": "float32",
+        "dispersion": False,  # Whether to include dispersion corrections
     }
 }
 

--- a/mofa/simulation/mace.py
+++ b/mofa/simulation/mace.py
@@ -6,7 +6,6 @@ import os
 
 import ase
 from mace.calculators import mace_mp
-from ase import units
 from ase.filters import UnitCellFilter
 from ase.io import Trajectory
 from ase.optimize import LBFGS

--- a/mofa/simulation/mace.py
+++ b/mofa/simulation/mace.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import os
 
 import ase
-from mace.calculators import MACECalculator
+from mace.calculators import mace_mp
 from ase import units
 from ase.filters import UnitCellFilter
 from ase.io import Trajectory
@@ -122,7 +122,7 @@ class MACERunner:
 
         try:
             # Initialize MACE calculator
-            calc = MACECalculator(**options)
+            calc = mace_mp(**options)
             atoms = atoms.copy()
             atoms.calc = calc
 

--- a/mofa/simulation/mace.py
+++ b/mofa/simulation/mace.py
@@ -14,9 +14,14 @@ from ase.optimize import LBFGS
 from mofa.model import MOFRecord
 from mofa.utils.conversions import read_from_string
 
+# Default model paths from MACE's pretrained models
+_default_model_path = (
+    "mace-mp-0"  # This will use MACE's built-in Materials Project model
+)
+
 _mace_options = {
     "default": {
-        "model": "medium",  # Can be 'small', 'medium', or 'large'
+        "model_paths": _default_model_path,  # Using Materials Project pretrained model
         "device": "cpu",  # Can be 'cpu' or 'cuda'
         "default_dtype": "float32",
     }

--- a/tests/simulation/test_mace.py
+++ b/tests/simulation/test_mace.py
@@ -1,0 +1,63 @@
+import os
+import shutil
+
+from pytest import mark
+
+from mofa.model import MOFRecord
+from mofa.simulation.mace import MACERunner
+from mofa.utils.conversions import write_to_string
+
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
+
+@mark.parametrize("cif_name", ["hMOF-0"])
+def test_mace_single(cif_name, cif_dir, tmpdir):
+    # Make a MACE simulator that reads and writes to a temporary directory
+    runner = MACERunner()
+
+    test_file = cif_dir / f"{cif_name}.cif"
+    record = MOFRecord.from_file(test_file)
+    record.md_trajectory["uff"] = [write_to_string(record.atoms, "vasp")]
+    atoms, mace_path = runner.run_single_point(record, structure_source=("uff", -1))
+
+    # Check that the computation completed and produced expected outputs
+    assert mace_path.exists()
+    assert mace_path.is_absolute()
+    assert "single" in mace_path.name
+    assert (mace_path / "atoms.json").exists()
+    assert atoms.get_potential_energy() is not None
+
+
+@mark.skipif(IN_GITHUB_ACTIONS, reason="Too expensive for CI")
+@mark.parametrize("cif_name", ["hMOF-0"])
+def test_mace_optimize(cif_name, cif_dir, tmpdir):
+    shutil.rmtree("mace-runs", ignore_errors=True)
+
+    # Make a MACE simulator that reads and writes to a temporary directory
+    runner = MACERunner()
+
+    test_file = cif_dir / f"{cif_name}.cif"
+    record = MOFRecord.from_file(test_file)
+    record.md_trajectory["uff"] = [write_to_string(record.atoms, "vasp")]
+    atoms, mace_path = runner.run_optimization(record, steps=2, fmax=0.1)
+
+    # Check that optimization produced expected changes and outputs
+    assert atoms != record.atoms
+    assert mace_path.exists()
+    assert mace_path.is_absolute()
+    assert "optimize" in mace_path.name
+    assert (mace_path / "atoms.json").exists()
+    assert (mace_path / "relax.traj").exists()
+    assert (mace_path / "relax.log").exists()
+    assert atoms.get_potential_energy() is not None
+
+
+@mark.parametrize("level", ["default"])
+def test_mace_options(level, cif_dir):
+    """Test that different MACE options work"""
+    runner = MACERunner()
+
+    test_file = cif_dir / "hMOF-0.cif"
+    record = MOFRecord.from_file(test_file)
+    atoms, mace_path = runner.run_single_point(record, level=level)
+    assert atoms.get_potential_energy() is not None

--- a/tests/simulation/test_mace.py
+++ b/tests/simulation/test_mace.py
@@ -6,9 +6,11 @@ from pytest import mark, importorskip
 # Try to import MACE and check if models are available
 mace = importorskip("mace")
 try:
-    from mace.calculators import MACECalculator
+    from mace.calculators import mace_mp
 
-    calc = MACECalculator(model_paths="mace-mp-0")
+    calc = mace_mp(
+        model="medium", dispersion=True, default_dtype="float32", device="cpu"
+    )
     MACE_AVAILABLE = True
 except (ImportError, ValueError, RuntimeError):
     MACE_AVAILABLE = False

--- a/tests/simulation/test_mace.py
+++ b/tests/simulation/test_mace.py
@@ -1,20 +1,7 @@
 import os
 import shutil
 
-from pytest import mark, importorskip
-
-# Try to import MACE and check if models are available
-mace = importorskip("mace")
-try:
-    from mace.calculators import mace_mp
-
-    calc = mace_mp(
-        model="medium", dispersion=False, default_dtype="float32", device="cpu"
-    )
-    MACE_AVAILABLE = True
-except (ImportError, ValueError, RuntimeError):
-    MACE_AVAILABLE = False
-
+from pytest import mark
 from mofa.model import MOFRecord
 from mofa.simulation.mace import MACERunner
 from mofa.utils.conversions import write_to_string
@@ -22,7 +9,6 @@ from mofa.utils.conversions import write_to_string
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
-@mark.skipif(not MACE_AVAILABLE, reason="MACE models not available")
 @mark.parametrize("cif_name", ["hMOF-0"])
 def test_mace_single(cif_name, cif_dir, tmpdir):
     # Make a MACE simulator that reads and writes to a temporary directory
@@ -41,7 +27,6 @@ def test_mace_single(cif_name, cif_dir, tmpdir):
     assert atoms.get_potential_energy() is not None
 
 
-@mark.skipif(not MACE_AVAILABLE, reason="MACE models not available")
 @mark.skipif(IN_GITHUB_ACTIONS, reason="Too expensive for CI")
 @mark.parametrize("cif_name", ["hMOF-0"])
 def test_mace_optimize(cif_name, cif_dir, tmpdir):
@@ -66,7 +51,6 @@ def test_mace_optimize(cif_name, cif_dir, tmpdir):
     assert atoms.get_potential_energy() is not None
 
 
-@mark.skipif(not MACE_AVAILABLE, reason="MACE models not available")
 @mark.parametrize("level", ["default"])
 def test_mace_options(level, cif_dir):
     """Test that different MACE options work"""

--- a/tests/simulation/test_mace.py
+++ b/tests/simulation/test_mace.py
@@ -1,7 +1,17 @@
 import os
 import shutil
 
-from pytest import mark
+from pytest import mark, importorskip
+
+# Try to import MACE and check if models are available
+mace = importorskip("mace")
+try:
+    from mace.calculators import MACECalculator
+
+    calc = MACECalculator(model_paths="mace-mp-0")
+    MACE_AVAILABLE = True
+except (ImportError, ValueError, RuntimeError):
+    MACE_AVAILABLE = False
 
 from mofa.model import MOFRecord
 from mofa.simulation.mace import MACERunner
@@ -10,6 +20,7 @@ from mofa.utils.conversions import write_to_string
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
+@mark.skipif(not MACE_AVAILABLE, reason="MACE models not available")
 @mark.parametrize("cif_name", ["hMOF-0"])
 def test_mace_single(cif_name, cif_dir, tmpdir):
     # Make a MACE simulator that reads and writes to a temporary directory
@@ -28,6 +39,7 @@ def test_mace_single(cif_name, cif_dir, tmpdir):
     assert atoms.get_potential_energy() is not None
 
 
+@mark.skipif(not MACE_AVAILABLE, reason="MACE models not available")
 @mark.skipif(IN_GITHUB_ACTIONS, reason="Too expensive for CI")
 @mark.parametrize("cif_name", ["hMOF-0"])
 def test_mace_optimize(cif_name, cif_dir, tmpdir):
@@ -52,6 +64,7 @@ def test_mace_optimize(cif_name, cif_dir, tmpdir):
     assert atoms.get_potential_energy() is not None
 
 
+@mark.skipif(not MACE_AVAILABLE, reason="MACE models not available")
 @mark.parametrize("level", ["default"])
 def test_mace_options(level, cif_dir):
     """Test that different MACE options work"""

--- a/tests/simulation/test_mace.py
+++ b/tests/simulation/test_mace.py
@@ -9,7 +9,7 @@ try:
     from mace.calculators import mace_mp
 
     calc = mace_mp(
-        model="medium", dispersion=True, default_dtype="float32", device="cpu"
+        model="medium", dispersion=False, default_dtype="float32", device="cpu"
     )
     MACE_AVAILABLE = True
 except (ImportError, ValueError, RuntimeError):


### PR DESCRIPTION
Adds MACE foundation models as ASE calculators to the workflow. Requires `pip install mace-torch`.