### PR TITLE
Switch back to mpiexec for Aurora

### DIFF
--- a/mofa/hpc/config.py
+++ b/mofa/hpc/config.py
@@ -534,7 +534,7 @@ hostname"""
                     )
                 )
                 ex.worker_task_port, ex.worker_result_port = ports
-                ex.worker_logdir = run_dir / 'runinfo' / f'{label}-workers'
+                ex.worker_logdir_root = run_dir / 'runinfo' / f'{label}-workers'
 
                 # Abuse Parsl's initialize_scaling to get the launch_cmd
                 #  TODO (wardlt): Make a formal route to making the launch_cmd in Parsl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
     'pytest-skip-slow',
     'pytest-timeout',
     'pytest-cov',
+    'pytest-mock',
     'mongomock'
 ]
 

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -58,12 +58,13 @@ def test_polaris(tmpdir):
         del os.environ['PBS_NODEFILE']
 
 
-def test_aurora(tmpdir):
+def test_aurora(tmpdir, mocker):
     hostfile_path = tmpdir / 'HOSTFILE'
     with open(hostfile_path, 'w') as fp:
         for i in range(20):
             print(f'host-{i}', file=fp)
     os.environ['PBS_NODEFILE'] = str(hostfile_path)
+    mocker.mock('subprocess.POpen')
 
     try:
         config = AuroraConfig()


### PR DESCRIPTION
This time fusing the launch of lammps and helper workers into a single call