### PR TITLE
Use mpiexec for all lammps nodes, limit helpers to a few

### DIFF
--- a/run-aurora-prod.sh
+++ b/run-aurora-prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -le
-#PBS -l select=128
-#PBS -l walltime=03:00:00
+#PBS -l select=1024
+#PBS -l walltime=0:15:00
 #PBS -l filesystems=home:flare
 #PBS -q prod
 #PBS -N mofa-prod

--- a/run-aurora-test.sh
+++ b/run-aurora-test.sh
@@ -41,7 +41,7 @@ python run_parallel_workflow.py \
       --compute-config aurora \
       --mace-model-path ./input-files/mace/mace-mp0_medium-lammps.pt \
       --md-timesteps 1000 \
-      --proxy-threshold 10000000 \
+      --proxy-threshold 1000 \
       --dft-opt-steps 1
 
 echo Python done


### PR DESCRIPTION
Avoid calling mpiexec more than once per node, but keep it because GNU Parallel will likely become problematic above 1000 nodes